### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -184,7 +184,7 @@ spec:
     spec:
       containers:
       - name: baton-cloudamqp
-        image: ghcr.io/conductorone/baton-cloudamqp:latest
+        image: public.ecr.aws/conductorone/baton-cloudamqp:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -209,5 +209,3 @@ spec:
 
 </Tab>
 </Tabs>
-
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._