### PR TITLE
docs: rename config field to Access token (CXH-2050)

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -84,7 +84,7 @@ To complete this task, you'll need:
   Find the **Settings** area of the page and click **Edit**.
   </Step>
   <Step>
-  In the **API key** field, enter the API key.
+  In the **Access token** field, enter the API key.
   </Step>
   <Step>
   Click **Save**.


### PR DESCRIPTION
## What

One-line fix in `docs/connector.mdx`: the C1 setup steps say to fill the **API key** field, but the config form now renders that field as **Access token**.

```diff
-  In the **API key** field, enter the API key.
+  In the **Access token** field, enter the API key.
```

## Why

PR #16 (containerization, CXH-2050) generates `config_schema.json`, which declares the credential field as:

```json
{
  "name": "token",
  "displayName": "Access token",
  "description": "The CloudAMQP access token used to connect to the CloudAMQP API.",
  "isRequired": true,
  "isSecret": true
}
```

So the label a user sees in C1 is "Access token", and the docs pointed at a field name that no longer exists in the form.

The CloudAMQP-side wording earlier in the page is deliberately left as "API key" — that is what CloudAMQP's own console calls the full-access key being copied.

## Validation

Found while validating CXH-2050 against the deployed containerized build (**v0.1.0**, channel `latest`) on a sandbox tenant. The config form was confirmed to render the field as "Access token", masked with a show/hide toggle, and the stored credential carried over on the existing app with no re-entry required.

Not publish lag: the in-repo file itself is stale on `main`, so it needs this change rather than waiting for a docs-site regeneration.

## Note

Separate from the open #15 (CXH-2049 provisioning docs) — that PR's branch also still carries the stale label, so these do not conflict but both touch `docs/connector.mdx`. Whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)