### PR TITLE
fix: recognize CloudAMQP's duplicate-invite 400 as already-invited

### DIFF
--- a/pkg/cloudamqp/client.go
+++ b/pkg/cloudamqp/client.go
@@ -192,7 +192,7 @@ func (c *Client) doRequest(
 	defer rawResponse.Body.Close()
 
 	if rawResponse.StatusCode >= 300 {
-		return status.Error(codes.Code(uint32(rawResponse.StatusCode)), "Request failed") //nolint:gosec // StatusCode is always valid HTTP code
+		return newAPIError(rawResponse.StatusCode, rawResponse.Body)
 	}
 
 	// Provisioning calls (invite/remove/update-role) pass a nil response target

--- a/pkg/cloudamqp/helpers.go
+++ b/pkg/cloudamqp/helpers.go
@@ -1,7 +1,10 @@
 package cloudamqp
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,6 +14,30 @@ import (
 // raw HTTP status code (see Client.doRequest). These helpers are the single
 // place that classification of those errors lives, used by the connector layer
 // for idempotency decisions (already-exists on create, not-found on delete).
+
+// apiErrorBody is the shape CloudAMQP uses for error responses, e.g.
+// {"error":"User is already invited"}.
+type apiErrorBody struct {
+	Error string `json:"error"`
+}
+
+// newAPIError builds a gRPC status error from a failed HTTP response, using the
+// raw status code and, when present, the vendor's JSON error message. The
+// message matters here: CloudAMQP answers both a duplicate invite and a
+// malformed email with the same HTTP 400, distinguishable only by this body
+// (see IsAlreadyInvitedError). If the body is missing or unparseable, fall back
+// to a generic message rather than fail the request over it.
+func newAPIError(statusCode int, body io.Reader) error {
+	msg := "Request failed"
+	if raw, err := io.ReadAll(body); err == nil && len(raw) > 0 {
+		var parsed apiErrorBody
+		if json.Unmarshal(raw, &parsed) == nil && parsed.Error != "" {
+			msg = parsed.Error
+		}
+	}
+	//nolint:gosec // statusCode is always a valid HTTP code
+	return status.Error(codes.Code(uint32(statusCode)), msg)
+}
 
 // IsNotFoundError reports whether err represents an HTTP 404 (or a NotFound
 // status produced by the client's own lookups).
@@ -30,4 +57,18 @@ func IsNotFoundError(err error) bool {
 // masked as "already exists".
 func IsAlreadyExistsError(err error) bool {
 	return status.Code(err) == codes.Code(http.StatusConflict)
+}
+
+// IsAlreadyInvitedError reports whether err represents CloudAMQP's response to
+// a duplicate POST /team/invite. Unlike member/invitation conflicts elsewhere
+// in the API, the invite endpoint never returns 409 for this case: both a
+// duplicate invite and a malformed email come back as HTTP 400, distinguished
+// only by the JSON error body ("User is already invited" vs "Invalid email").
+// Matching on the raw HTTP 400 alone would misclassify a genuine validation
+// failure as already-invited, so the message must be checked too.
+func IsAlreadyInvitedError(err error) bool {
+	if status.Code(err) != codes.Code(http.StatusBadRequest) {
+		return false
+	}
+	return strings.Contains(strings.ToLower(status.Convert(err).Message()), "already invited")
 }

--- a/pkg/cloudamqp/helpers.go
+++ b/pkg/cloudamqp/helpers.go
@@ -15,6 +15,15 @@ import (
 // place that classification of those errors lives, used by the connector layer
 // for idempotency decisions (already-exists on create, not-found on delete).
 
+// maxAPIErrorBodyBytes bounds how much of a failed response body newAPIError
+// reads. CloudAMQP's error bodies are a short {"error":"..."} object; this
+// just keeps a misbehaving upstream from forcing an unbounded read.
+const maxAPIErrorBodyBytes = 1 << 16
+
+// alreadyInvitedMsgFragment is the substring CloudAMQP's error message carries
+// for a duplicate POST /team/invite (see IsAlreadyInvitedError).
+const alreadyInvitedMsgFragment = "already invited"
+
 // apiErrorBody is the shape CloudAMQP uses for error responses, e.g.
 // {"error":"User is already invited"}.
 type apiErrorBody struct {
@@ -29,13 +38,13 @@ type apiErrorBody struct {
 // to a generic message rather than fail the request over it.
 func newAPIError(statusCode int, body io.Reader) error {
 	msg := "Request failed"
-	if raw, err := io.ReadAll(body); err == nil && len(raw) > 0 {
+	if raw, err := io.ReadAll(io.LimitReader(body, maxAPIErrorBodyBytes)); err == nil && len(raw) > 0 {
 		var parsed apiErrorBody
 		if json.Unmarshal(raw, &parsed) == nil && parsed.Error != "" {
 			msg = parsed.Error
 		}
 	}
-	//nolint:gosec // statusCode is always a valid HTTP code
+	//nolint:gosec // statusCode is always a valid HTTP code, so the int-to-uint32 conversion cannot overflow or wrap
 	return status.Error(codes.Code(uint32(statusCode)), msg)
 }
 
@@ -70,5 +79,5 @@ func IsAlreadyInvitedError(err error) bool {
 	if status.Code(err) != codes.Code(http.StatusBadRequest) {
 		return false
 	}
-	return strings.Contains(strings.ToLower(status.Convert(err).Message()), "already invited")
+	return strings.Contains(strings.ToLower(status.Convert(err).Message()), alreadyInvitedMsgFragment)
 }

--- a/pkg/cloudamqp/helpers_test.go
+++ b/pkg/cloudamqp/helpers_test.go
@@ -1,0 +1,55 @@
+package cloudamqp
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestNewAPIError pins that the vendor's JSON error body becomes the status
+// message, since IsAlreadyInvitedError depends on that message to distinguish
+// a duplicate invite from other HTTP 400s.
+func TestNewAPIError(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		code    int
+		body    string
+		wantMsg string
+	}{
+		{name: "already invited", code: 400, body: `{"error":"User is already invited"}`, wantMsg: "User is already invited"},
+		{name: "invalid email", code: 400, body: `{"error":"Invalid email"}`, wantMsg: "Invalid email"},
+		{name: "empty body falls back", code: 500, body: "", wantMsg: "Request failed"},
+		{name: "unparseable body falls back", code: 500, body: "not json", wantMsg: "Request failed"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := newAPIError(tt.code, strings.NewReader(tt.body))
+			if status.Code(err) != codes.Code(uint32(tt.code)) { //nolint:gosec
+				t.Fatalf("code = %v, want %d", status.Code(err), tt.code)
+			}
+			if status.Convert(err).Message() != tt.wantMsg {
+				t.Fatalf("message = %q, want %q", status.Convert(err).Message(), tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestIsAlreadyInvitedError(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "duplicate invite", err: newAPIError(400, strings.NewReader(`{"error":"User is already invited"}`)), want: true},
+		{name: "invalid email is not a duplicate", err: newAPIError(400, strings.NewReader(`{"error":"Invalid email"}`)), want: false},
+		{name: "409 conflict is not this error", err: newAPIError(409, strings.NewReader(`{"error":"User is already invited"}`)), want: false},
+		{name: "nil error", err: nil, want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAlreadyInvitedError(tt.err); got != tt.want {
+				t.Fatalf("IsAlreadyInvitedError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cloudamqp/helpers_test.go
+++ b/pkg/cloudamqp/helpers_test.go
@@ -25,7 +25,7 @@ func TestNewAPIError(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := newAPIError(tt.code, strings.NewReader(tt.body))
-			if status.Code(err) != codes.Code(uint32(tt.code)) { //nolint:gosec
+			if status.Code(err) != codes.Code(uint32(tt.code)) { //nolint:gosec // tt.code is always a small literal HTTP status in this test table
 				t.Fatalf("code = %v, want %d", status.Code(err), tt.code)
 			}
 			if status.Convert(err).Message() != tt.wantMsg {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -252,7 +252,7 @@ func (u *userResourceType) CreateAccount(
 			}
 			return &v2.CreateAccountResponse_AlreadyExistsResult{Resource: res}, nil, nil, nil
 		} else if !cloudamqp.IsNotFoundError(ferr) {
-			return nil, nil, nil, fmt.Errorf("baton-cloudamqp: create account: failed to re-resolve member %s after 409: %w", email, ferr)
+			return nil, nil, nil, fmt.Errorf("baton-cloudamqp: create account: failed to re-resolve member %s after already-exists invite response: %w", email, ferr)
 		}
 		return &v2.CreateAccountResponse_ActionRequiredResult{
 			Message:               fmt.Sprintf("Invitation already pending for %s. The user must accept the email invitation to complete account creation.", email),

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -239,10 +239,12 @@ func (u *userResourceType) CreateAccount(
 
 	// Step 2: send the invitation.
 	if err := u.client.InviteUser(ctx, email, role, tags); err != nil {
-		if !cloudamqp.IsAlreadyExistsError(err) {
+		// CloudAMQP answers a duplicate invite with HTTP 400, not 409 (see
+		// IsAlreadyInvitedError), so both must be checked here.
+		if !cloudamqp.IsAlreadyExistsError(err) && !cloudamqp.IsAlreadyInvitedError(err) {
 			return nil, nil, nil, fmt.Errorf("baton-cloudamqp: create account: failed to invite %s: %w", email, err)
 		}
-		// Invite reported already-exists: re-resolve to decide member vs pending.
+		// Invite reported already-exists/already-invited: re-resolve to decide member vs pending.
 		if existing, ferr := u.client.GetUserByEmail(ctx, email); ferr == nil {
 			res, resErr := userResource(ctx, existing)
 			if resErr != nil {


### PR DESCRIPTION
## Summary
- `CreateAccount`'s retry path only treated HTTP 409 as already-exists, but CloudAMQP's `POST /team/invite` never returns 409 — a duplicate invite and a malformed email both come back as HTTP 400, distinguishable only by the JSON error body.
- The client now reads that body on error responses and preserves the vendor message (e.g. `"User is already invited"`, `"Invalid email"`) instead of discarding it.
- Added `cloudamqp.IsAlreadyInvitedError`, which matches HTTP 400 + a message containing "already invited", and wired it into `CreateAccount`'s invite-error handling alongside the existing 409 check.

This lets a re-driven provisioning task (the C1 retry after the invitee hasn't yet accepted the first invite) land on the existing "invitation already pending" `ActionRequiredResult` path instead of hard-failing the task.

Fixes [CXH-2233](https://linear.app/ductone/issue/CXH-2233/baton-cloudamqp-createaccount-treats-cloudamqps-duplicate-invite-400).

Note: the exact vendor message string (`"User is already invited"`) is sourced from the ticket's live-API reproduction, not from CloudAMQP's published docs — if the wording ever changes on their end, this match will need to be revisited.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1` (21 tests passing, including new `pkg/cloudamqp/helpers_test.go` cases for `newAPIError` and `IsAlreadyInvitedError`)
- [ ] Manual repro against a live CloudAMQP tenant (not available in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)